### PR TITLE
Case Login with blank password credentials

### DIFF
--- a/tests/actions/LoginActions.js
+++ b/tests/actions/LoginActions.js
@@ -45,4 +45,15 @@ export default class SwaglabsLogin {
         await expect(this.MsgRequired).toContainText('Epic sadface: Username is required');  
     }
 
+    async LoginBlankPassword(){
+        await this.InputUsername.fill('standard_user');
+        await expect(this.InputUsername).toHaveValue('standard_user');
+        await this.InputPassword.fill ('');
+        await expect(this.InputPassword).toHaveValue('');
+        await this.ButtonLogin.click();
+
+        await expect(this.MsgRequired).toBeVisible();
+        await expect(this.MsgRequired).toContainText('Epic sadface: Password is required');  
+    }
+
 }

--- a/tests/assertions.spec.js
+++ b/tests/assertions.spec.js
@@ -17,5 +17,11 @@ test('Login blank credentials', async ({ page }) => {
 test('Login with blank username credentials', async ({ page }) => {
     const objActions = new loginActions(page);
     await objActions.goto();
-    await objActions. LoginBlankUsername();
+    await objActions.LoginBlankUsername();
+});
+
+test('Login with blank password credentials', async ({ page }) => {
+    const objActions = new loginActions(page);
+    await objActions.goto();
+    await objActions.LoginBlankPassword();
 });


### PR DESCRIPTION
**Description:**
This test case ensures that when a valid username is provided and the password is left blank, the login attempt will fail and an appropriate error message will be shown.

**Pre-conditions:**
- The user is not logged in yet.
- The login page is accessible.

**Test Steps:**
1. Open the login page.
2. Enter a valid username (e.g., standard_user).
3. Leave the password field blank.
4. Click the Login button.

**Expected Result:**
An error message should appear, indicating that the password is required, and the login attempt should fail.