### PR TITLE
Case Login invalid credentials

### DIFF
--- a/tests/actions/LoginActions.js
+++ b/tests/actions/LoginActions.js
@@ -56,4 +56,17 @@ export default class SwaglabsLogin {
         await expect(this.MsgRequired).toContainText('Epic sadface: Password is required');  
     }
 
+    async LoginInvalidUser(){
+        await this.InputUsername.fill('niken');
+        await expect(this.InputUsername).toHaveValue('niken');
+        await this.InputPassword.fill ('nikencantik');
+        await expect(this.InputPassword).toHaveValue('nikencantik');
+        await this.ButtonLogin.click();
+
+        await expect(this.MsgRequired).toBeVisible();
+        await expect(this.MsgRequired).toContainText('Epic sadface: Username and password do not match any user in this service');  
+    }
+
+    
+
 }

--- a/tests/assertions.spec.js
+++ b/tests/assertions.spec.js
@@ -25,3 +25,9 @@ test('Login with blank password credentials', async ({ page }) => {
     await objActions.goto();
     await objActions.LoginBlankPassword();
 });
+
+test('Login Invalid credentials', async ({ page }) => {
+    const objActions = new loginActions(page);
+    await objActions.goto();
+    await objActions.LoginInvalidUser();
+});


### PR DESCRIPTION
**Description:**
Verify that the user cannot log in with invalid username and/or password.

**Pre-conditions:**
- The user is not logged into the application.
- The application’s login page is accessible.

**Test Steps:**
Access the application’s login page.
Enter an invalid username (niken).
Enter an invalid password (nikencantik).
Click the Login button.

**Expected Result:**
The user should see an error message indicating that the credentials are incorrect. The login attempt should fail, and the user should remain on the login page